### PR TITLE
Fix typo in confidence dataset

### DIFF
--- a/confidence/dataset.py
+++ b/confidence/dataset.py
@@ -213,7 +213,7 @@ class ConfidenceDataset(Dataset):
         t_to_sigma = partial(t_to_sigma_compl, args=self.original_model_args)
 
         model = get_model(self.original_model_args, self.device, t_to_sigma=t_to_sigma, no_parallel=True)
-        state_dict = torch.load(f'{self.original_model_dir}/{self.model_ckpt}.pt', map_location=torch.device('cpu'))
+        state_dict = torch.load(f'{self.original_model_dir}/{self.model_ckpt}', map_location=torch.device('cpu'))
         model.load_state_dict(state_dict, strict=True)
         model = model.to(self.device)
         model.eval()


### PR DESCRIPTION
Default value of `self.model_ckpt` already end with `.pt`

https://github.com/gcorso/DiffDock/blob/73ef67ffcff263cf0b1fe013c8418f541a6531c1/confidence/confidence_train.py#L31