### PR TITLE
Remove hyperparameter notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ If you have any question, feel free to open an issue or reach out to us: [gcorso
 The repository also contains all the scripts to run the baselines and generate the figures.
 Additionally, there are visualization videos in `visualizations`.
 
-You might also be interested in this awesome [interactive online tool](https://huggingface.co/spaces/simonduerr/diffdock) by Simon Duerr on Hugging Face for running DiffDock and visualising the predicted structures on your browser, however note that this does not use the optimal hyperparameters for the reverse diffusion which instead are provided below. Instead, Brian Naughton made a [Google Colab notebook](https://colab.research.google.com/drive/1nvCyQkbO-TwXZKJ0RCShVEym1aFWxlkX) to run DiffDock. 
+You might also be interested in this awesome [interactive online tool](https://huggingface.co/spaces/simonduerr/diffdock) by Simon Duerr on Hugging Face for running DiffDock and visualising the predicted structures on your browser. There is also a [Google Colab notebook](https://colab.research.google.com/drive/1nvCyQkbO-TwXZKJ0RCShVEym1aFWxlkX) to run DiffDock by Brian Naughton. 
 
+[![Open in Spaces](https://huggingface.co/datasets/huggingface/badges/raw/main/open-in-hf-spaces-lg-dark.svg)](https://huggingface.co/spaces/simonduerr/diffdock)
 
 
 # Dataset


### PR DESCRIPTION
Due to a runtime error I had to update the space to pin pytorch geometric to 2.1.0 and also updated the space to run with the same default options as described here, so I think this notice can be removed. I keep the number of samples at 10 for now due to runtime constraints but people can set it higher if they want. 

I think the colab notebook also needs to fix the dependency, it threw a few errors when I tried it earlier: `pip install git+https://github.com/pyg-team/pytorch_geometric.git@2.1.0 `