### PR TITLE
Fixing key error

### DIFF
--- a/utils/inference_utils.py
+++ b/utils/inference_utils.py
@@ -188,7 +188,7 @@ class InferenceDataset(Dataset):
             self.lm_embeddings = []
             for i in range(len(protein_sequences)):
                 s = protein_sequences[i].split(':')
-                self.lm_embeddings.append([lm_embeddings[f'{complex_names[i]}chain{j}'] for j in range(len(s))])
+                self.lm_embeddings.append([lm_embeddings[f'{complex_names[i]}_chain_{j}'] for j in range(len(s))])
 
         elif not lm_embeddings:
             self.lm_embeddings = [None] * len(self.complex_names)


### PR DESCRIPTION
The key for loading embeddings from a dictionary is inconsistent with the one used to store the embedding in the dictionary, raising a key error when using the code for inference (docking).