### PR TITLE
Upgrade `e3nn` to fix batch normalization runtime issue with `final_conv` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This is an example for how to set up a working conda environment to run the code
     conda activate diffdock
     conda install pytorch==1.11.0 pytorch-cuda=11.7 -c pytorch -c nvidia
     pip install torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric==2.0.4 -f https://data.pyg.org/whl/torch-1.11.0+cu117.html
-    python -m pip install PyYAML scipy "networkx[default]" biopython rdkit-pypi e3nn spyrmsd pandas biopandas
+    python -m pip install PyYAML scipy "networkx[default]" biopython rdkit-pypi e3nn spyrmsd pandas biopandas wandb
 
 Then you need to install ESM that we use both for protein sequence embeddings and for the protein structure prediction in case you only have the sequence of your target. Note that OpenFold (and so ESMFold) requires a GPU. If you don't have a GPU, you can still use DiffDock with existing protein structures.
 

--- a/environment.yml
+++ b/environment.yml
@@ -73,7 +73,7 @@ dependencies:
   - pip:
     - biopandas==0.4.1
     - biopython==1.79
-    - e3nn==0.5.0
+    - e3nn==0.5.1
     - jinja2==3.1.2
     - joblib==1.2.0
     - markupsafe==2.1.1


### PR DESCRIPTION
Starting with version `0.5.1` of `e3nn`, the authors of the library are now guarding against attempting to aggregate scalar means if no scalar irreps are given as input: https://github.com/e3nn/e3nn/blob/bb71b3c75c38c6d633cfebe9988b1fb1563432c0/e3nn/nn/_batchnorm.py#L191

(This PR also adds `wandb` to the installation instructions for new Conda environments)

It's possible version `0.5.0` of `e3nn` was pinned accidentally, even though the source code will only run with `0.5.1` of `e3nn`. I hope this helps!