### PR TITLE
Upated docker commands instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,20 @@ First, download the container from Docker Hub:
 
     docker pull rbgcsail/diffdock
 
+Check if you have a GPU available
+
+    docker run --rm --gpus all nvidia/cuda:11.7.1-devel-ubuntu22.04 nvidia-smi
+
 Then, run the container:
 
-    docker run -it --entrypoint /bin/bash rbgcsail/diffdock
-    # Inside the container
+    docker run -it --gpus all --entrypoint /bin/bash rbgcsail/diffdock 
+
+If you don't have a GPU, run (it will be significantly slower):
+    
+    docker run -it --entrypoint /bin/bash rbgcsail/diffdock 
+
+Inside the container
+
     micromamba activate diffdock
 
 You can now run the code as described below.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [conda documentation](https://conda.io/projects/conda/en/latest/commands/env
 
 A Dockerfile is provided for building a container:
 
-    docker build -f Dockerfile -t diffdock
+    docker build . -f Dockerfile -t diffdock
 
 Alternatively, you can use a pre-built container to run the code.
 First, download the container from Docker Hub:


### PR DESCRIPTION
Small update in the README: The build command is currently failing as is. It’s missing the dot to build in the current folder.

Update: Also updated Docker run commands so I clear how to run and test with GPU support. 