### PR TITLE
update torus.py to use absolute paths

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,12 @@
+The key changes I made to torus.py
+
+1. Added `SCRIPT_DIR` to get the absolute path of the directory where torus.py is located
+2. Created absolute paths for the cache files using `os.path.join(SCRIPT_DIR, '.p.npy')`
+3. Added print statements for debugging to show when and where files are being created
+4. Improved the condition to check for both cache files before loading them
+
+This should solve the issue because:
+
+1. Now it will look for and save the cache files in the same directory as the script itself, regardless of where the script is being run from
+2. The added debugging prints will help you see if/when the cache files are being created
+3. The script will explicitly check that both required cache files exist before trying to load them

--- a/utils/torus.py
+++ b/utils/torus.py
@@ -7,6 +7,8 @@ import os
     cached to memory, therefore the precomputation is only run the first time the repository is run on a machine
 """
 
+# Get the directory where this script is located for absolute paths
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def p(x, sigma, N=10):
     p_ = 0
@@ -28,16 +30,22 @@ SIGMA_MIN, SIGMA_MAX, SIGMA_N = 3e-3, 2, 5000  # relative to pi
 x = 10 ** np.linspace(np.log10(X_MIN), 0, X_N + 1) * np.pi
 sigma = 10 ** np.linspace(np.log10(SIGMA_MIN), np.log10(SIGMA_MAX), SIGMA_N + 1) * np.pi
 
-if os.path.exists('.p.npy'):
-    p_ = np.load('.p.npy')
-    score_ = np.load('.score.npy')
+# Use absolute paths for cache files
+p_cache_file = os.path.join(SCRIPT_DIR, '.p.npy')
+score_cache_file = os.path.join(SCRIPT_DIR, '.score.npy')
+
+if os.path.exists(p_cache_file) and os.path.exists(score_cache_file):
+    p_ = np.load(p_cache_file)
+    score_ = np.load(score_cache_file)
 else:
+    print(f"Cache files not found. Computing and saving to {SCRIPT_DIR}")
     p_ = p(x, sigma[:, None], N=100)
-    np.save('.p.npy', p_)
+    np.save(p_cache_file, p_)
 
     eps = np.finfo(p_.dtype).eps
     score_ = grad(x, sigma[:, None], N=100) / (p_ + eps)
-    np.save('.score.npy', score_)
+    np.save(score_cache_file, score_)
+    print(f"Cache files created successfully at {SCRIPT_DIR}")
 
 
 def score(x, sigma):


### PR DESCRIPTION
Running `inference` on a Slurm cluster with `sbatch` failed to create the cache file *.score.npy* on the expected path as *torus.py* was using relative paths which doesn't get inherited correctly during the submission. Plus *torus.py* failed to trigger a meaningful message as to why the cache file wasn't on the expected path. This modified version 

1. will look for and save the cache files in the same directory as the script itself, regardless of where the script is being run from
2.  added debugging prints will help you see if/when the cache files are being created
3. script will explicitly check that both required cache files exist before trying to load them